### PR TITLE
Add IO

### DIFF
--- a/foo/src/lib.rs
+++ b/foo/src/lib.rs
@@ -3,7 +3,7 @@
 pub struct Byte32Reader<'r>(pub &'r [u8]);
 
 impl<'r> Byte32Reader<'r> {
-    #[cfg_attr(feature = "inline-unpack", inline)]
+    #[inline]
     pub fn unpack(&self) -> [u8; 32] {
         self.0.try_into().expect("unpack Byte32Reader")
     }
@@ -12,11 +12,24 @@ impl<'r> Byte32Reader<'r> {
 pub struct Byte32<'r>(pub &'r [u8]);
 
 impl<'r> Byte32<'r> {
+    #[inline]
     pub fn as_reader(&self) -> Byte32Reader {
         Byte32Reader(self.0)
     }
 
+    #[inline]
     pub fn unpack(&self) -> [u8; 32] {
         self.as_reader().unpack()
     }
+
+    pub fn unpack_noninline(&self) -> [u8; 32] {
+        self.as_reader().unpack()
+    }
+}
+
+pub fn input() -> [u8; 32] {
+    [0u8; 32]
+}
+
+pub fn output(_: &[u8; 32]) {
 }

--- a/main/src/main.rs
+++ b/main/src/main.rs
@@ -1,5 +1,7 @@
 pub fn main() {
-    let b = foo::Byte32(&[0; 32]);
-    let a = b.unpack();
-    std::process::exit(a.len() as i32);
+    let input = foo::input();
+    let result = foo::Byte32(&input).unpack();
+    foo::output(&result);
+    let result = foo::Byte32(&input).unpack_noninline();
+    foo::output(&result);
 }


### PR DESCRIPTION
加了 IO, 然后直接对比有 inline 和没有 inline 的 unpack:

```
(lldb) disassemble -n main::main
main`main::main::h3a3d78ffc3da0794:
main[0x6a30] <+0>:  pushq  %r14
main[0x6a32] <+2>:  pushq  %rbx
main[0x6a33] <+3>:  subq   $0x78, %rsp
main[0x6a37] <+7>:  leaq   0x38(%rsp), %rbx
main[0x6a3c] <+12>: movq   %rbx, %rdi
main[0x6a3f] <+15>: callq  *0x4127b(%rip)            ; _GLOBAL_OFFSET_TABLE_ + 720
; 内联的没有 bounds check, 直接生成 SSE2 指令完成复制
main[0x6a45] <+21>: movups 0x38(%rsp), %xmm0
main[0x6a4a] <+26>: movups 0x48(%rsp), %xmm1
main[0x6a4f] <+31>: movaps %xmm1, 0x20(%rsp)
main[0x6a54] <+36>: movaps %xmm0, 0x10(%rsp)
main[0x6a59] <+41>: leaq   0x170(%rip), %r14         ; foo::output::ha9077af115268d2e at lib.rs:35:2
main[0x6a60] <+48>: leaq   0x10(%rsp), %rdi
main[0x6a65] <+53>: callq  *%r14
main[0x6a68] <+56>: movq   %rbx, (%rsp)
main[0x6a6c] <+60>: movq   $0x20, 0x8(%rsp)
main[0x6a75] <+69>: leaq   0x58(%rsp), %rbx
main[0x6a7a] <+74>: movq   %rsp, %rsi
main[0x6a7d] <+77>: movq   %rbx, %rdi
; 不内联的话要去调用，内部要 bounds checking.
main[0x6a80] <+80>: callq  *0x4131a(%rip)            ; _GLOBAL_OFFSET_TABLE_ + 944
main[0x6a86] <+86>: movq   %rbx, %rdi
main[0x6a89] <+89>: callq  *%r14
main[0x6a8c] <+92>: addq   $0x78, %rsp
main[0x6a90] <+96>: popq   %rbx
main[0x6a91] <+97>: popq   %r14
main[0x6a93] <+99>: retq   
```

虽然估计也不是性能瓶颈，但应该是属于 low-hanging fruit 的性能优化。